### PR TITLE
Update rdf toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 *.xlsx
 .DS_Store
 catalog-backup-0.xml
-/tools/serializer/rdf-toolkit.jar

--- a/tools/serializer/pre-commit
+++ b/tools/serializer/pre-commit
@@ -203,13 +203,8 @@ __log_config__
       permissions=$(stat -c "%a" "${file}")
       chmod $permissions "${file}X"
       rm  "${file}"
-      
-      log "Patching serializer erroneous change of -x- in language tag to -X-"
-      sed 's/-X-/-x-/g' "${file}X" > "${file}"
-      rm  "${file}X"  
-
+      mv  "${file}X" "${file}"
       git add --update "${file}"
-
     else
       log_error "sesame-serializer ended with error code ${rc}"
     fi
@@ -227,17 +222,6 @@ function serialize_all() {
   return 0
 }
 
-function remove_skos_decls () {
-  for fileToBeCommitted in $(git diff --cached --name-only) ; do
-    permissions=$(stat -c "%a" "${fileToBeCommitted}")
-    sed -e '/^skos/,+3d' "$fileToBeCommitted" > tmp$$
-    mv tmp$$ "$fileToBeCommitted"
-    chmod $permissions "${fileToBeCommitted}"
-    git add --update "${fileToBeCommitted}"
-  done
-
-  return 0
-}
 
 function main() {
   findBaseDir || return 1
@@ -247,7 +231,7 @@ function main() {
   findSerializerJar || return 3
 
   serialize_all || return 4
-  remove_skos_decls || return 5
+
 }
 
 main $*

--- a/tools/serializer/serialize.sh
+++ b/tools/serializer/serialize.sh
@@ -8,9 +8,9 @@ usage() {
     echo Formats RDF files into a standard format. Operates on a single file, all files in a directory, or a set of files specified with a wildcard. Files are assumed to have either .owl or .ttl extension. Assumes rdf-toolkit.jar is in the same directory as this script.
     echo Usage: $scriptname [ file \| directory \| wildcard expression ]
     echo Examples:
-    echo $scriptname ./ontoechoies/gistCore.ttl
-    echo $scriptname ../ontoechoies
-    echo "$scriptname ../ontoechoies/*.owl"
+    echo $scriptname ./ontologies/gistCore.ttl
+    echo $scriptname ../ontologies
+    echo "$scriptname ../ontologies/*.owl"
 }
 
 serialize_file() {
@@ -30,16 +30,11 @@ serialize_file() {
         echo Skipping file $file. 
         return
     fi
-    
-    echo Reserializing $file into a standard format.
+    echo Serializing $file into a standard format.
     tmp=$file.bak
     cp $file $tmp
-    java -jar `dirname "$0"`/rdf-toolkit.jar -tfmt $format -sdt explicit -dtd -ibn -s $file -t $tmp
-
-    echo Patching serializer erroneous change of -x- in language tag to -X-
-    sed 's/-X-/-x-/g' $tmp > $file 
-    rm -f $tmp
-
+    java -jar `dirname "$0"`/rdf-toolkit.jar -tfmt $format -sdt explicit -dtd -ibn -sni -s $file -t $tmp 
+    mv $tmp $file
 }
 
 serialize_directory() {


### PR DESCRIPTION
Update to release 1.15 (still incorrectly versioned as 1.14.2) to fix bug that transformed "-x-" in private language tags to "-X-". Patch in pre-commit hook no longer needed. Copied all tools files other than rdf-toolkit.jar from gist repo.